### PR TITLE
Add missing p2p-billing configuration to config.ini

### DIFF
--- a/xprNode/config.ini
+++ b/xprNode/config.ini
@@ -117,3 +117,5 @@ p2p-peer-address = mainnet.brotonbp.com:9876
 p2p-peer-address = proton.eu.eosamsterdam.net:9103
 p2p-peer-address = peer1.proton.pink.gg:48011
 p2p-peer-address = proton.genereos.io:9876
+
+disable-subjective-p2p-billing = false


### PR DESCRIPTION
Added the following line for block producing nodes:  disable-subjective-p2p-billing = false