### PR TITLE
major error on the fullnode config

### DIFF
--- a/xprNode/config.ini
+++ b/xprNode/config.ini
@@ -23,7 +23,7 @@
     
     contracts-console = true
     
-    p2p-max-nodes-per-host = 100
+    p2p-max-nodes-per-host = 2
     
     chain-threads = 8
     http-threads = 6


### PR DESCRIPTION
refer to the latest fullnode config, there are p2p-max-nodes-per-host = 100 and max-clients = 100, with this config, the malicious node could occupy all the incoming connections of the target node with one node to make others unable to connect the target node that will be harmful to the network healthy, the correct config may be p2p-max-nodes-per-host = 2