### PR TITLE
Update P2P peer lists with verified active endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ List staked/delegated
 ```
 cleos system listbw <account>
 ```
-## XPR Network MAINNET P2P
+## XPR Network MAINNET P2P (Verified January 2026)
 
 ```
 api.protonnz.com:9876
@@ -215,10 +215,7 @@ protonp2p.blocksindia.com:9876
 p2p-protonmain.saltant.io:9876
 protonp2p.ledgerwise.io:23877
 proton-seed.eosiomadrid.io:9876
-proton.edenia.cloud:9879
 proton.genereos.io:9876
-peer-proton.nodeone.network:9870
-p2p.proton.eoseoul.io:39876
 proton-public.neftyblocks.com:19876
 p2p-proton.eosarabia.net:9876
 p2p.luminaryvisn.com:9876

--- a/xprNode/get_p2p_nodes.sh
+++ b/xprNode/get_p2p_nodes.sh
@@ -10,7 +10,7 @@ echo "Checking p2p nodes, this may take a few minutes...."
 # Get the directory where the script is located
 script_dir=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 
-# ---------- Fallback static list (from xpr.start README) ----------
+# ---------- Fallback static list (verified January 2026) ----------
 fallback_addresses=(
   "api.protonnz.com:9876"
   "proton.protonuk.io:9876"
@@ -25,12 +25,10 @@ fallback_addresses=(
   "p2p-protonmain.saltant.io:9876"
   "protonp2p.ledgerwise.io:23877"
   "proton-seed.eosiomadrid.io:9876"
-  "proton.edenia.cloud:9879"
   "proton.genereos.io:9876"
-  "peer-proton.nodeone.network:9870"
-  "p2p.proton.eoseoul.io:39876"
   "proton-public.neftyblocks.com:19876"
   "p2p-proton.eosarabia.net:9876"
+  "p2p.luminaryvisn.com:9876"
 )
 
 # ---------- Try to fetch the p2p list from API ----------


### PR DESCRIPTION
## Summary

- Remove 3 inactive peers from README P2P list
- Update `get_p2p_nodes.sh` fallback list to match verified peers
- Add luminaryvisn endpoint

## Removed Inactive Peers

| Peer | Status |
|------|--------|
| `proton.edenia.cloud:9879` | Inactive |
| `peer-proton.nodeone.network:9870` | Inactive |
| `p2p.proton.eoseoul.io:39876` | Inactive |

## Verification Method

All peers tested via TCP connectivity check (nc -z) with 2 second timeout.

## Test Plan

- [x] 17 peers verified active via TCP connectivity test
- [x] Fallback list in get_p2p_nodes.sh updated to match

🤖 Generated with [Claude Code](https://claude.ai/code)